### PR TITLE
Enable mipmapping and anisotropic filtering

### DIFF
--- a/src/pvQtView.cpp
+++ b/src/pvQtView.cpp
@@ -817,7 +817,13 @@ void pvQtView::initializeGL()
     glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     // 2d maps...
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+
+    glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE);
+
+    float anisotropy = 0.0f;
+    glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &anisotropy);
+    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, anisotropy);
 
     // enable alpha blending for overlay
     glEnable (GL_BLEND);


### PR DESCRIPTION
Significantly enhances rendering quality, especially for high resolution images.

Before:
![2018-09-02-191640_1600x900_scrot](https://user-images.githubusercontent.com/10910745/44958309-32eef680-aee7-11e8-8614-e6ff34aaddbf.jpg)

After:
![2018-09-02-192429_1600x900_scrot](https://user-images.githubusercontent.com/10910745/44958310-33878d00-aee7-11e8-9ed5-091a49fcb835.jpg)
